### PR TITLE
Attempt to fix issue #34. ID creation for empty INFO field

### DIFF
--- a/bin/vcfMerger2.py
+++ b/bin/vcfMerger2.py
@@ -1201,6 +1201,8 @@ def main(args, cmdline):
         dryrun = args["dry_run"]
         log.info("dry-run?:" + str(dryrun))
     
+    log.warning(f'IMPORTANT NOTE: To ensure correct merged vcf outputs, you MUST make sure that when passing the values to the `--toolnames` and `--vcfs` options, the order of the toolnames and the order or the toolname-specific vcf match. otherwise vcfMerger2 team is not responsible for the merging errors.')
+    
     # @@@@@@@@@
     #  MAIN  #
     # @@@@@@@@@

--- a/merge_vcfs/dvmfuncs.py
+++ b/merge_vcfs/dvmfuncs.py
@@ -96,6 +96,18 @@ def addHeaderToOutVcf(t_obj, f):
 	log.info("in function addHeaderToOutVcf" + str(t_obj) + str(f))
 
 
+def add_tag_for_toolname_if_INFO_empty(toolname):
+	"""
+		In case we have no data or information in the INFO field for any of the tool, we generate a header line for each tools
+		even if there is information in the INFO field.
+		This was added because `deepsomatic` tool had no info in the INFO column and that generated an error with
+		`bcftools view` because the `DEEPSOMATIC_.` ID did not exist in the header despite the fact it existed in the records.
+		So has a workaround, we generate that ID for all the tool, for code update simplicity
+	"""
+	log.info('add by default the TAG toolname_. in case the tool does not have any information in the INFO field, but just a dot as allowed by VCF specifications')
+	return f'##INFO=<ID={toolname}_.,Number=1,Type=String,Description="tool had no information in the INFO field">'
+
+
 def prefix_headers_information_line_with_toolname(myHeaderString, toolname):
 	"""
 	Prefixing the Flags in the INFO fields with the name of the tool they come from
@@ -119,7 +131,7 @@ def prefix_headers_other_information_line_with_toolname(myHeaderString, toolname
 def create_new_header_for_merged_vcf(tuple_objs, command_line, vcfMerger_Format_Fields_Specific, vcfMerger_Info_Fields_Specific, dico_map_tool_acronym, list_contig_from_fastadict_captured_as_is):
 	"""
 	Manage the Headers from all the input VCFs and recreate a brand new updated Header
-	:param: tuple of vcf2dict objects which containg ALL the information about each input vcfs
+	:param: tuple of `vcf2dict` objects which contains ALL the information about each input vcf
 	:param: String of the Command line captured by sys.argv value
 	:param: vcfMerger_Format_Fields_Specific is a list of strings with the strings being ready to be added to header lines
 	:param: vcfMerger_Info_Fields_Specific is a list of strings with the strings being ready to be added to header lines
@@ -225,6 +237,9 @@ def create_new_header_for_merged_vcf(tuple_objs, command_line, vcfMerger_Format_
 			lh.append(prefix_headers_information_line_with_toolname(s, toolname_or_acronym))
 		for s in vtdo.header_other_info:
 			lh.append(prefix_headers_other_information_line_with_toolname(s, toolname_or_acronym))
+		# adding IDs in case INFO field is empty
+		lh.append(add_tag_for_toolname_if_INFO_empty(toolname_or_acronym))
+		
 		# ## if LOSSLESS, the column QUAL, FILTER, ID, and some others are ADDED to the variant record
 		# ## this creates NEW fields prefixed with the toolname
 		for COLUMN in ["FILTER", "QUAL", "ID"]:
@@ -402,7 +417,7 @@ def renameINFO_IDS(obj_variant, toolname):
 
 def addINFO_FromSecondaryToolsToNewRebuiltINFO_Field(currentNewRebuiltINFO, obj_variant, toolname):
 	"""
-	Get the Format field information from the remaining tools and add them to the newINFO column
+	Get the INFO field information from the remaining tools and add them to the newINFO column
 	:param obj_variant: cyvcf2 object represent the variant object
 	:param toolname: string name of the tool that called the variant
 	:param currentNewRebuiltINFO:

--- a/merge_vcfs/dvmfuncs.py
+++ b/merge_vcfs/dvmfuncs.py
@@ -95,19 +95,6 @@ def get_list_contig_from_fasta_dict_file(dicofilename):
 def addHeaderToOutVcf(t_obj, f):
 	log.info("in function addHeaderToOutVcf" + str(t_obj) + str(f))
 
-
-def add_tag_for_toolname_if_INFO_empty(toolname):
-	"""
-		In case we have no data or information in the INFO field for any of the tool, we generate a header line for each tools
-		even if there is information in the INFO field.
-		This was added because `deepsomatic` tool had no info in the INFO column and that generated an error with
-		`bcftools view` because the `DEEPSOMATIC_.` ID did not exist in the header despite the fact it existed in the records.
-		So has a workaround, we generate that ID for all the tool, for code update simplicity
-	"""
-	log.info('add by default the TAG toolname_. in case the tool does not have any information in the INFO field, but just a dot as allowed by VCF specifications')
-	return f'##INFO=<ID={toolname}_.,Number=1,Type=String,Description="tool had no information in the INFO field">'
-
-
 def prefix_headers_information_line_with_toolname(myHeaderString, toolname):
 	"""
 	Prefixing the Flags in the INFO fields with the name of the tool they come from
@@ -237,8 +224,6 @@ def create_new_header_for_merged_vcf(tuple_objs, command_line, vcfMerger_Format_
 			lh.append(prefix_headers_information_line_with_toolname(s, toolname_or_acronym))
 		for s in vtdo.header_other_info:
 			lh.append(prefix_headers_other_information_line_with_toolname(s, toolname_or_acronym))
-		# adding IDs in case INFO field is empty
-		lh.append(add_tag_for_toolname_if_INFO_empty(toolname_or_acronym))
 		
 		# ## if LOSSLESS, the column QUAL, FILTER, ID, and some others are ADDED to the variant record
 		# ## this creates NEW fields prefixed with the toolname

--- a/merge_vcfs/dvmfuncs.py
+++ b/merge_vcfs/dvmfuncs.py
@@ -118,7 +118,7 @@ def prefix_headers_other_information_line_with_toolname(myHeaderString, toolname
 def create_new_header_for_merged_vcf(tuple_objs, command_line, vcfMerger_Format_Fields_Specific, vcfMerger_Info_Fields_Specific, dico_map_tool_acronym, list_contig_from_fastadict_captured_as_is):
 	"""
 	Manage the Headers from all the input VCFs and recreate a brand new updated Header
-	:param: tuple of `vcf2dict` objects which contains ALL the information about each input vcf
+	:param: tuple of `vcf2dict`  objects which contains ALL the information about each input vcf
 	:param: String of the Command line captured by sys.argv value
 	:param: vcfMerger_Format_Fields_Specific is a list of strings with the strings being ready to be added to header lines
 	:param: vcfMerger_Info_Fields_Specific is a list of strings with the strings being ready to be added to header lines
@@ -392,7 +392,7 @@ def isOfTYPE(ref, alt, v):  # we need to elaborate here ALL the possibilities to
 def renameINFO_IDS(obj_variant, toolname):
 	"""
 	Prefixing the Flags in the INFO fields with the name of the tool they come from
-	:param obj_variant: cyvcf2 object repreent the variant object
+	:param obj_variant: cyvcf2 object represent the variant object
 	:param toolname: string name of the tool that called the variant
 	:return: String
 	"""
@@ -640,7 +640,7 @@ def rebuiltVariantLine(LV, dico_map_tool_acronym, lossless, list_Fields_Format, 
 
 	# LV = List Variant from each Tool @ the Same Position;  calls are from minimum 1 to maximum N tools at the same
 	# position;
-	wtn = LV[0][0]  # ## wtv stands for Winner Tool Name
+	wtn = LV[0][0]  # ## wtn stands for Winner Tool Name
 	wtv = LV[0][1]  # ## wtv stands for Winner Tool Variant (here Variant refers to the Object Variant Created by
 	# cyvcf2
 	# ## 1) we first deal with re-building INFO field

--- a/merge_vcfs/dvmfuncs.py
+++ b/merge_vcfs/dvmfuncs.py
@@ -396,6 +396,10 @@ def renameINFO_IDS(obj_variant, toolname):
 	:param toolname: string name of the tool that called the variant
 	:return: String
 	"""
+
+	if str(obj_variant).split("\t")[8-1] == ".":
+		# if the INFO field is empty, we need to report nothing for the current tool; We know that in the merged VCF, our INFO column will NEVER be empty since we will have at least the CC= and the TPCE flags
+		return ""
 	return re.sub(r"^", ''.join([toolname.upper(), "_"]), str(obj_variant).split("\t")[8-1].replace(
 		";", ''.join([";", toolname.upper(), "_"]))).strip(';')
 
@@ -408,6 +412,9 @@ def addINFO_FromSecondaryToolsToNewRebuiltINFO_Field(currentNewRebuiltINFO, obj_
 	:param currentNewRebuiltINFO:
 	:return: NewCurrentRebuiltINFO_String
 	"""
+	if str(obj_variant).split("\t")[(8 - 1)] == ".":
+		# if the INFO field is empty (represented by a dot according to VCF specs), we return the current new rebuiltINFO.
+		return currentNewRebuiltINFO
 	# column_number=8 ; indice = column_number-1 ; # ## python is 0-based ; column 8 is INFO column in VCF
 	delim = "" if len(currentNewRebuiltINFO) == 0 else ";"
 	newInfoToAppend = re.sub(r"^", ''.join([toolname.upper(), "_"]),
@@ -455,13 +462,14 @@ def add_ID_FILTER_QUAL_FromSecondaryToolsToNewRebuiltINFO_Field(currentNewRebuil
 	# Columns 10 and beyond represent the format values for each sample in the VCF
 	delim = ";"
 	prefix_name_ID = "_".join([toolname, "ID"])
-	ID = str(tv).split("\t")[(3 - 1)][0]
+	ID = str(tv).split("\t")[(3 - 1)]
 	prefix_name_QUAL = "_".join([toolname, "QUAL"])
-	QUAL = str(tv).split("\t")[(6 - 1)][0]
+	QUAL = str(tv).split("\t")[(6 - 1)]
 	prefix_name_FILTER = "_".join([toolname, "FILTER"])
 	FILTER = str(tv).split("\t")[(7 - 1)].replace(";", ",")
-	
-	local_rebuilt = str(prefix_name_ID) + "=" + str(ID) + ";" + str(prefix_name_QUAL) + "=" + str(QUAL) + ";" + str(prefix_name_FILTER) + "=" + str(FILTER)
+	local_rebuilt = str(prefix_name_QUAL) + "=" + str(QUAL) + ";" + str(prefix_name_FILTER) + "=" + str(FILTER)
+	if ID != ".":
+		local_rebuilt = str(prefix_name_ID) + "=" + str(ID) + ";" + str(prefix_name_QUAL) + "=" + str(QUAL) + ";" + str(prefix_name_FILTER) + "=" + str(FILTER)
 	return delim.join([currentNewRebuiltINFO, local_rebuilt]).strip(';')
 
 


### PR DESCRIPTION
## BUG FIXING
 - fix issue #34
 - If the INFO field is empty, represented by a dot according to VCF specs, we do not want to carry over the information in the __new__ `INFO` field. Absence of information can be rebuilt by `bcftools` for instance if we needed to rebuilt the original vcf used to create the merged one.  _NOTE_: we are still lossless doing that way.
 - The empty `INFO` issue raised the same issue for the ID column. We performed the same type of check `is the field empty?` as with INFO  and do not carry over to the new `INFO` column the absence of ID from "other" tools.
- Fix QUAL value in new INFO